### PR TITLE
Add test to check if numeric keys are removed

### DIFF
--- a/tests/tests/ArrayEncodingTest.php
+++ b/tests/tests/ArrayEncodingTest.php
@@ -155,6 +155,30 @@ class ArrayEncodingTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testAlignedArrayOmitsDefaultKeys()
+    {
+
+        $encoder = new PHPEncoder(['array.omit' => true, 'array.align' => true]);
+
+        $input  = [0 => 'The Doctor', 1 => 'Martha Jones', 2 => 'Rose Tyler', 3 => 'Clara'];
+        $output = $encoder->encode($input);
+
+        $expected = <<<EOP
+[
+    'The Doctor',
+    'Martha Jones',
+    'Rose Tyler',
+    'Clara'
+]
+EOP;
+
+        $this->assertEquals(
+            $expected,
+            $output,
+            'Encoding did not produce aligned output with redundant numeric keys omitted.'
+        );
+    }
+
     private function assertEncode($value, $string, PHPEncoder $encoder, $initial = null)
     {
         $output = $encoder->encode(func_num_args() < 4 ? $value : $initial);


### PR DESCRIPTION
There is a suspected bug where the output string does not have numeric array keys removed (when `array.omit => true`) if `array.align` is also set to `true`.

I added a test case to verify it's existence. As I understand from the README (option documentation), this is not the intended behavior. Could you verify and look into it?
